### PR TITLE
Changes order of Docker steps, lowers default launch_dev perms

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -15,12 +15,16 @@ RUN mkdir explorer
 # set that directory as working dir
 WORKDIR /explorer
 
-# copy the contents of current file into the
-# working directory.
-COPY ./ /explorer/
+# environment first
+COPY ./Pipfile.lock /explorer/ 
+COPY ./Pipfile /explorer/ 
 
 # install required modules at system level
 RUN pipenv install --system --deploy
+
+# copy the contents of current file into the
+# working directory.
+COPY ./ /explorer/
 
 # run app
 # Description of how to choose the number of workers and threads.

--- a/Dockerfile.supervisor_workers
+++ b/Dockerfile.supervisor_workers
@@ -21,12 +21,16 @@ RUN mkdir explorer
 # set that directory as working dir
 WORKDIR /explorer
 
-# copy the contents of current file into the
-# working directory.
-COPY ./ /explorer/
+# environment first
+COPY ./Pipfile.lock /explorer/ 
+COPY ./Pipfile /explorer/ 
 
 # install required modules at system level
 RUN pipenv install --system --deploy
+
+# copy the contents of current file into the
+# working directory.
+COPY ./ /explorer/
 
 # run supervisord
 CMD supervisord

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -16,12 +16,16 @@ RUN mkdir explorer
 # set that directory as working dir
 WORKDIR /explorer
 
-# copy the contents of current file into the
-# working directory.
-COPY ./ /explorer/
+# environment first
+COPY ./Pipfile.lock /explorer/ 
+COPY ./Pipfile /explorer/ 
 
 # install required modules at system level
 RUN pipenv install --system --deploy
+
+# copy the contents of current file into the
+# working directory.
+COPY ./ /explorer/
 
 # run worker
 CMD rq worker -c worker_settings

--- a/scripts/launch_dev.sh
+++ b/scripts/launch_dev.sh
@@ -1,3 +1,12 @@
+# It's common to have access permission denied by the Docker Daemon
+# on Linux machines if you don't run Docker with root permissions.
+
+# If containers aren't created because of a 'permission denied' error
+# or other by Docker, run this script as '$ sudo bash scripts/launch_dev.sh'
+
+# Docker is working on running rootless but this hasn't been implemented
+# yet. It sometimes works on Mac but not always.
+
 # can pass target port number to script for redis as: bash ./this_script.sh <new_port>
 # TODO redis doesn't currently like this and I'm not sure why
 if [ -z "$1" ]
@@ -18,14 +27,14 @@ fi
 docker network create eightknot-network ;
 
 # create a redis instance inside of a container, on our docker network, mapped to its respective port. 
-sudo docker run --rm -itd --name redis --net eightknot-network -p $REDIS_PORT_MAP:6379 redis;
+docker run --rm -itd --name redis --net eightknot-network -p $REDIS_PORT_MAP:6379 redis;
 
 # grab the route to the redis server from the running redis container
 REDIS_CONTAINER_URL=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' redis);
 printf "\nRedis URL is: ${REDIS_CONTAINER_URL}:${REDIS_PORT_MAP}\n";
 
 # build and run the worker pool
-sudo docker build -f Dockerfile.supervisor_workers -t worker_pool .;
+docker build -f Dockerfile.supervisor_workers -t worker_pool .;
 docker run --rm -dit --name worker_pool \
                      --net eightknot-network \
                      --env REDIS_SERVICE_HOST=$REDIS_CONTAINER_URL \
@@ -33,8 +42,8 @@ docker run --rm -dit --name worker_pool \
                      worker_pool;
 
 # build and run the web server
-sudo docker build -f Dockerfile.server -t eightknot_server .;
-sudo docker run --rm -it --name eightknot_server \
+docker build -f Dockerfile.server -t eightknot_server .;
+docker run --rm -it --name eightknot_server \
                          --net eightknot-network \
                          --env REDIS_SERVICE_HOST=$REDIS_CONTAINER_URL \
                          --env REDIS_SERVICE_PORT=$REDIS_PORT_MAP \
@@ -44,10 +53,10 @@ sudo docker run --rm -it --name eightknot_server \
 
 # cleanup
 printf "\nShutting down worker pool...\n"
-sudo docker stop worker_pool;
+docker stop worker_pool;
 
 printf "\nShutting down redis...\n"
-sudo docker stop redis;
+docker stop redis;
 
 printf "\nRemaining containers:\n"
 docker ps -a;


### PR DESCRIPTION
Moves folder file-copy operation in Dockerfiles to step following environment installation steps so that updates to files don't trigger an environment redownload.

Also lowers default permissions in /scripts/launch_dev.sh to non-sudo. Can run everything w/ sudo permissions by:

'$ sudo bash scripts/launch_dev.sh'

Signed-off-by: James Kunstle <jkunstle@bu.edu>