### PR TITLE
decreases default pools of workers, rq and gunicorn

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -27,4 +27,4 @@ COPY ./ /explorer/
 # Description of how to choose the number of workers and threads.
 # common wisdom is (2*CPU)+1 workers:
 # https://medium.com/building-the-system/gunicorn-3-means-of-concurrency-efbb547674b7
-CMD [ "gunicorn", "--bind", ":8050", "app:server", "--workers", "8", "--threads", "4" ]
+CMD [ "gunicorn", "--bind", ":8050", "app:server", "--workers", "4", "--threads", "2" ]

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:worker]
-numprocs=128
+numprocs=32
 # require scheduler because we're allowing each job 3 retries
 command=rq worker -c worker_settings --with-scheduler
 process_name=%(program_name)s_%(process_num)02d


### PR DESCRIPTION
fewer workers- 4 gunicorn workers and 32 rq workers at a time

This should decrease the load on development machines.

Signed-off-by: James Kunstle <jkunstle@bu.edu>