### PR TITLE
update: switch from dockerhub to registry.redhat.access

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,4 +1,4 @@
-FROM docker.io/python:3.10
+FROM registry.access.redhat.com/ubi9/python-39 
 
 # need this for the Dash app
 EXPOSE 8050

--- a/Dockerfile.supervisor_workers
+++ b/Dockerfile.supervisor_workers
@@ -1,4 +1,4 @@
-FROM docker.io/python:3.10
+FROM registry.access.redhat.com/ubi9/python-39 
 
 # need this for the Dash app
 EXPOSE 8050

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,4 +1,4 @@
-FROM docker.io/python:3.10
+FROM registry.access.redhat.com/ubi9/python-39 
 
 # need this for the Dash app
 EXPOSE 8050


### PR DESCRIPTION
dockerhub access is limited on ocp, should use
red hat's 'universal base image' ubi-9 for python.

forces us back to 3.9 but that's okay.

Signed-off-by: James Kunstle <jkunstle@bu.edu>