### PR TITLE
fewer concurrent threads for Dockerfile.worker

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -28,4 +28,4 @@ COPY ./ /explorer/
 
 # run worker
 # CMD [ "rq", "worker", "-c", "worker_settings" ]
-CMD ["celery", "-A", "app:celery_app", "worker", "--loglevel=DEBUG", "--concurrency=15"]
+CMD ["celery", "-A", "app:celery_app", "worker", "--loglevel=DEBUG", "--concurrency=2"]

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -4,7 +4,7 @@ nodaemon=true
 [program:worker]
 numprocs=2
 # require scheduler because we're allowing each job 3 retries
-command=celery -A app:celery_app worker --loglevel=DEBUG --concurrency=6 --without-heartbeat --without-mingle --without-heartbeat
+command=celery -A app:celery_app worker --loglevel=DEBUG --concurrency=4 --without-heartbeat --without-mingle --without-heartbeat
 process_name=%(program_name)s_%(process_num)02d
 autostart=true
 autorestart=true


### PR DESCRIPTION
having trouble on openshift w/ too many threads of execution in individual pods. decreasing this default value.

Signed-off-by: James Kunstle <jkunstle@bu.edu>